### PR TITLE
Timestamp should be u64 per AMQP spec

### DIFF
--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -41,7 +41,7 @@ pub enum AMQPType {
     LongString,
     /// An array of AMQPValue
     FieldArray,
-    /// A timestamp (u32)
+    /// A timestamp (u64)
     Timestamp,
     /// A Map<String, AMQPValue>
     FieldTable,
@@ -141,7 +141,7 @@ pub type LongLongUInt = u64;
 pub type Float = f32;
 /// A f64
 pub type Double = f64;
-/// A timestamp (u32)
+/// A timestamp (u64)
 pub type Timestamp = LongLongUInt;
 /// No value
 pub type Void = ();

--- a/types/src/value.rs
+++ b/types/src/value.rs
@@ -34,7 +34,7 @@ pub enum AMQPValue {
     LongString(LongString),
     /// An array of AMQPValue
     FieldArray(FieldArray),
-    /// A timestamp (u32)
+    /// A timestamp (u64)
     Timestamp(Timestamp),
     /// A Map<String, AMQPValue>
     FieldTable(FieldTable),


### PR DESCRIPTION
The documentation of timestamp was not correct. Per AMQP spec (and also because of the type alias) it should be u64.