### PR TITLE
Allow lossy UTF-8 parsing of LongString values

### DIFF
--- a/types/src/parsing.rs
+++ b/types/src/parsing.rs
@@ -205,6 +205,10 @@ fn make_str<I: nom::InputIter<Item = u8>>(i: I) -> Result<String, std::string::F
     String::from_utf8(i.iter_elements().collect())
 }
 
+fn make_str_lossy<I: nom::InputIter<Item = u8>>(i: I) -> String {
+    String::from_utf8_lossy(&i.iter_elements().collect::<Vec<_>>()).into_owned()
+}
+
 /// Parse a [ShortString](../type.ShortString.html)
 pub fn parse_short_string<I: ParsableInput>(i: I) -> ParserResult<I, ShortString> {
     context(
@@ -221,7 +225,7 @@ pub fn parse_long_string<I: ParsableInput>(i: I) -> ParserResult<I, LongString> 
     context(
         "parse_long_string",
         map(
-            map_res(flat_map(parse_long_uint, take), make_str),
+            map(flat_map(parse_long_uint, take), make_str_lossy),
             LongString::from,
         ),
     )(i)


### PR DESCRIPTION
According to the spec `LongString` may contain arbitrary octet streams. Ideally, `Vec<u8>` would be the correct representation, but that requires a compatibility break (so is appropriate for 7.x, but not an option for 6.x).

Workaround for #28

Branched this off the last 6.x release (6.0.2), so that existing Lapin users (such as us :P) don't need to wait for 7.x to come out and percolate up the dependency tree, but there isn't currently. A separate PR is coming up for changing the types for 7.x.